### PR TITLE
Call to random() fails in sqlite3

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,11 @@ class ApplicationController < ActionController::Base
     seed = session["#{controller_name}_random_sort_seed"] ||= rand(2147483647)
     direction = %w(asc desc).include?(params[:order]) ? params[:order].upcase : ''
 
-    "RAND(#{seed}) #{direction}"
+    if ActiveRecord::Base.configurations[Rails.env]['adapter'] == 'sqlite3'
+      "RANDOM() #{direction}"
+    else
+      "RAND(#{seed}) #{direction}"
+    end
   end
 
   def clear_random_sort_seed


### PR DESCRIPTION
Have the application_controller::random_sort_clause check the db adapter in use so sql call to random() passes for sqlite3; otherwise assume mysql usage.
