### PR TITLE
Updated to allow for s3 storage from paperclip.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ gem 'thinking-sphinx', '~> 2.0.1', :require => 'thinking_sphinx'
 
 #--[ Model ]--------------------------------------------------------------------
 gem "paperclip", "~> 2.3"
+# If using s3 for file storage, uncomment to install the required aws-s3 gem
+# gem "aws-s3", "~> 0.6.2"
 gem "inherited_resources", "~> 1.3.0"
 gem "responders", "~> 0.6.2"
 

--- a/app/mixins/import_image_from_url.rb
+++ b/app/mixins/import_image_from_url.rb
@@ -42,7 +42,8 @@ module ImportImageFromURL
       }
 
       # Activate PaperClip attachment on field
-      self.has_attached_file(field, :styles => leaf[:thumbnail_styles])
+      options = { :styles => leaf[:thumbnail_styles] }.merge(SETTINGS['image_upload'].symbolize_keys)
+      self.has_attached_file(field, options)
 
       # Validate size of attachment
       self.validates_attachment_size(field, :less_than => leaf[:maximum_size])

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -4,7 +4,8 @@ class Company < ActiveRecord::Base
   acts_as_taggable_on :tags, :technologies
   sortable :created_at, :desc
 
-  has_attached_file :logo, :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename"
+  options = { :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename" }.merge(SETTINGS['image_upload'].symbolize_keys)
+  has_attached_file :logo, options
 
   default_serialization_options :include => { :projects => {:include => [:tags, :technologies]}, 
                                               :groups => {:include => [:tags, :technologies]},

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,7 +4,8 @@ class Group < ActiveRecord::Base
   acts_as_taggable_on :tags, :technologies
   sortable :created_at, :desc
 
-  has_attached_file :logo, :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename"
+  options = { :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename" }.merge(SETTINGS['image_upload'].symbolize_keys)
+  has_attached_file :logo, options
 
   default_serialization_options :include => { :projects => {:include => [:tags, :technologies]}, 
                                               :companies => {:include => [:tags, :technologies]},

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,8 @@ class Project < ActiveRecord::Base
   acts_as_taggable_on :tags, :technologies
   sortable :created_at, :desc
 
-  has_attached_file :logo, :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename"
+  options = { :styles => { :medium => '220x220', :thumb => '48x48' }, :url => "/system/:attachment/:id/:style/:safe_filename" }.merge(SETTINGS['image_upload'].symbolize_keys)
+  has_attached_file :logo, options
 
   default_serialization_options :include => { :people => {:include => [:tags, :technologies]}, 
                                               :companies => {:include => [:tags, :technologies]},

--- a/config/settings-sample.yml
+++ b/config/settings-sample.yml
@@ -46,6 +46,14 @@ common:
     default_from: contact@domain.localhost
   search: sql
   mentoring: false # enables experimental mentor matching features
+  # Avatar and logo image uploads
+  image_upload:
+    # if you choose storage: s3, uncomment bucket, access_key_id, and secret_access_key with your s3 credentials
+    storage: filesystem
+    #s3_credentials:
+    #  bucket: bucket-name
+    #  access_key_id: skeletonkey
+    #  secret_access_key: seekrit!
 
 development:
   auth_credentials:


### PR DESCRIPTION
I updated citizenry to allow for s3 storage from paperclip (for the avatar and logo uploads/import from url). It still uses the filesystem by default (just as before), but now allows the user to easily change it to s3 from the settings.yml.

This would also allow for easier hosting on heroku (see reidab/citizenry#45), since it's necessary to persist images across deploys.
