### PR TITLE
Restrict PaperTrailManager access to admins only

### DIFF
--- a/config/initializers/paper_trail_manager.rb
+++ b/config/initializers/paper_trail_manager.rb
@@ -1,1 +1,6 @@
 PaperTrailManager.whodunnit_class = User
+
+is_admin = proc { |controller| controller.current_user.try(:admin?) }
+PaperTrailManager.allow_index_when(&is_admin)
+PaperTrailManager.allow_show_when(&is_admin)
+PaperTrailManager.allow_revert_when(&is_admin)


### PR DESCRIPTION
In a new installation of Citizenry and on ePDX, PaperTrailManager is accessible to the public allowing anyone to revert any record. I sent an email about this a while ago, but I just came across the change feed in Google results once again and wanted to make sure this gets fixed. Thanks!
